### PR TITLE
Implemented status/log collection process. #19 #21

### DIFF
--- a/assemblerflow/generator/process.py
+++ b/assemblerflow/generator/process.py
@@ -155,7 +155,7 @@ class Process:
         ``{"link": <link string>, "alias":<string for template>}``
         """
 
-        self.status_channels = ["STATUS"]
+        self.status_channels = ["STATUS_{}".format(template)]
         """
         list: Name of the status channels produced by the process. By default,
         it sets a single status channel. If more than one status channels
@@ -675,7 +675,7 @@ class FastQC(Process):
         self.input_type = "fastq"
         self.output_type = "fastq"
 
-        self.status_channels = ["STATUS_fastqc", "STATUS_report"]
+        self.status_channels = ["STATUS_fastqc2", "STATUS_fastqc2_report"]
         """
         list: Setting status channels for FastQC execution and FastQC report
         """
@@ -754,8 +754,8 @@ class FastqcTrimmomatic(Process):
 
         self.link_end.append({"link": "SIDE_phred", "alias": "SIDE_phred"})
 
-        self.status_channels = ["STATUS_fastqc", "STATUS_report",
-                                "STATUS_trim"]
+        self.status_channels = ["STATUS_fastqc", "STATUS_fastqc_report",
+                                "STATUS_trimmomatic"]
 
         self.secondary_inputs = [
             {
@@ -878,7 +878,8 @@ class AssemblyMapping(Process):
         self.input_type = "fasta"
         self.output_type = "fasta"
 
-        self.status_channels = ["STATUS_am", "STATUS_amp"]
+        self.status_channels = ["STATUS_assembly_mapping",
+                                "STATUS_process_am"]
 
         self.link_start.append("SIDE_BpCoverage")
         self.link_end.append({"link": "__fastq", "alias": "_LAST_fastq"})
@@ -920,6 +921,7 @@ class Pilon(Process):
         self.output_type = "fasta"
 
         self.dependencies = ["assembly_mapping"]
+        self.status_channels = ["STATUS_pilon", "STATUS_pilon_report"]
 
         self.link_end.append({"link": "SIDE_BpCoverage",
                               "alias": "SIDE_BpCoverage"})
@@ -971,6 +973,8 @@ class Abricate(Process):
         self.output_type = None
 
         self.ignore_type = True
+
+        self.status_channels = ["STATUS_abricate", "STATUS_process_abricate"]
 
         self.link_start = None
         self.link_end.append({"link": "MAIN_assembly",
@@ -1059,6 +1063,5 @@ class StatusCompiler(Status):
         super().__init__(**kwargs)
 
         self.ignore_type = True
-
         self.link_start = None
 

--- a/assemblerflow/generator/templates/abricate.nf
+++ b/assemblerflow/generator/templates/abricate.nf
@@ -13,7 +13,9 @@ process abricate {
 
     output:
     file '*.tsv' into abricate_out_{{ pid }}
-    set fastq_id, val("abricate_${db}"), file(".status"), file(".warning"), file(".fail") into STATUS_{{ pid }}
+    {% with task_name="abricate" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     when:
     params.abricateRun == true && params.annotationRun
@@ -43,7 +45,9 @@ process process_abricate {
     file abricate_file from abricate_out_{{ pid }}.collect()
 
     output:
-    file ".report.json"
+    {% with task_name="process_abricate" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     script:
     template "process_abricate.py"

--- a/assemblerflow/generator/templates/assembly_mapping.nf
+++ b/assemblerflow/generator/templates/assembly_mapping.nf
@@ -12,7 +12,9 @@ process assembly_mapping {
     output:
     set fastq_id, file(assembly), 'coverages.tsv', 'coverage_per_bp.tsv', 'sorted.bam', 'sorted.bam.bai' optional true into MAIN_am_out_{{ pid }}
     set fastq_id, file("coverage_per_bp.tsv") optional true into SIDE_BpCoverage_{{ pid }}
-    set fastq_id, val("assembly_mapping"), file(".status"), file(".warning"), file(".fail") into STATUS_am_{{ pid }}
+    {% with task_name="assembly_mapping" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     when:
     params.stopAt != "assembly_mapping"
@@ -74,8 +76,9 @@ process process_assembly_mapping {
 
     output:
     set fastq_id, '*_filtered.assembly.fasta', 'filtered.bam', 'filtered.bam.bai' optional true into {{ output_channel }}
-    set fastq_id, val("process_am"), file(".status"), file(".warning"), file(".fail") into STATUS_amp_{{ pid }}
-    file ".report.json"
+    {% with task_name="process_am" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     script:
     template "process_assembly_mapping.py"

--- a/assemblerflow/generator/templates/check_coverage.nf
+++ b/assemblerflow/generator/templates/check_coverage.nf
@@ -7,24 +7,25 @@ process integrity_coverage_2 {
     tag { fastq_id + " getStats" }
     cpus 1
 
-	input:
-	set fastq_id, file(fastq_pair) from {{ input_channel }}
-	val gsize from IN_genome_size
-	val cov from IN_min_coverage
-	// Use -e option for skipping encoding guess
-	val opts from Channel.value('-e')
+    input:
+    set fastq_id, file(fastq_pair) from {{ input_channel }}
+    val gsize from IN_genome_size
+    val cov from IN_min_coverage
+    // Use -e option for skipping encoding guess
+    val opts from Channel.value('-e')
 
-	output:
-	set fastq_id,
-	    file(fastq_pair),
-	    file('*_coverage'),
-	    file('*_max_len') optional true into MAIN_integrity_{{ pid }}
-	file('*_report') into LOG_report_coverage_{{ pid }}
-	set fastq_id, val("integrity_coverage2_{{ pid }}"), file(".status"), file(".warning"), file(".fail") into STATUS_{{ pid }}
-	file ".report.json"
+    output:
+    set fastq_id,
+        file(fastq_pair),
+        file('*_coverage'),
+        file('*_max_len') optional true into MAIN_integrity_{{ pid }}
+    file('*_report') into LOG_report_coverage_{{ pid }}
+    {% with task_name="check_coverage" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
-	script:
-	template "integrity_coverage.py"
+    script:
+    template "integrity_coverage.py"
 }
 
 {{ output_channel }} = Channel.create()

--- a/assemblerflow/generator/templates/chewbbaca.nf
+++ b/assemblerflow/generator/templates/chewbbaca.nf
@@ -18,8 +18,9 @@ process chewbbaca {
 
     output:
     file 'chew_results'
-    set fastq_id, val("chewbbaca"), file(".status"), file(".warning"), file(".fail") into STATUS_{{ pid }}
-    file '.report.json'
+    {% with task_name="chewbbaca" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     when:
     params.chewbbacaRun == true

--- a/assemblerflow/generator/templates/compiler_channels.txt
+++ b/assemblerflow/generator/templates/compiler_channels.txt
@@ -1,0 +1,2 @@
+set fastq_id, val("{{ task_name }}_{{ pid }}"), file(".status"), file(".warning"), file(".fail"), file(".command.log") into STATUS_{{task_name}}_{{ pid }}
+file ".report.json"

--- a/assemblerflow/generator/templates/fastqc.nf
+++ b/assemblerflow/generator/templates/fastqc.nf
@@ -12,8 +12,9 @@ process fastqc2 {
 
     output:
     set fastq_id, file(fastq_pair), file('pair_1*'), file('pair_2*') optional true into MAIN_fastqc_out_{{ pid }}
-    set fastq_id, val("fastqc2_{{ pid }}"), file(".status"), file(".warning"), file(".fail") into STATUS_fastqc_{{ pid }}
-    file ".report.json"
+    {% with task_name="fastqc2" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     when:
     params.stopAt != "fastqc2"
@@ -42,9 +43,10 @@ process fastqc2_report {
     output:
     set fastq_id, file(fastq_pair), '.status' into MAIN_fastqc_report_{{ pid }}
     file "*_status_report" into LOG_fastqc_report_{{ pid }}
-    set fastq_id, val("fastqc2_report_{{ pid }}"), file(".status"), file(".warning"), file(".fail") into STATUS_report_{{ pid }}
     file "${fastq_id}_*_summary.txt" optional true
-    file ".report.json"
+    {% with task_name="fastqc2_report" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     script:
     template "fastqc_report.py"

--- a/assemblerflow/generator/templates/fastqc_trimmomatic.nf
+++ b/assemblerflow/generator/templates/fastqc_trimmomatic.nf
@@ -12,8 +12,9 @@ process fastqc {
 
     output:
     set fastq_id, file(fastq_pair), file('pair_1*'), file('pair_2*') optional true into MAIN_fastqc_out_{{ pid }}
-    set fastq_id, val("fastqc_{{ pid }}"), file(".status"), file(".warning"), file(".fail") into STATUS_fastqc_{{ pid }}
-    file ".report.json"
+    {% with task_name="fastqc" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     when:
     params.stopAt != "fastqc"
@@ -45,10 +46,11 @@ process fastqc_report {
     output:
     set fastq_id, file(fastq_pair), 'optimal_trim', ".status" into MAIN_fastqc_trim
     file '*_trim_report' into LOG_trim_{{ pid }}
-    set fastq_id, val("fastqc_report_{{ pid }}"), file(".status"), file(".warning"), file(".fail") into STATUS_report_{{ pid }}
     file "*_status_report" into LOG_fastqc_report_{{ pid }}
     file "${fastq_id}_*_summary.txt" optional true
-    file ".report.json"
+    {% with task_name="fastqc_report" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     script:
     template "fastqc_report.py"
@@ -120,9 +122,10 @@ process trimmomatic {
 
     output:
     set fastq_id, "${fastq_id}_*P*" optional true into {{ output_channel }}
-    set fastq_id, val("trimmomatic_{{ pid }}"), file(".status"), file(".warning"), file(".fail") into STATUS_trim_{{ pid }}
     file 'trimmomatic_report.csv'
-    file ".report.json"
+    {% with task_name="trimmomatic" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     when:
     params.stopAt != "trimmomatic"

--- a/assemblerflow/generator/templates/integrity_coverage.nf
+++ b/assemblerflow/generator/templates/integrity_coverage.nf
@@ -8,24 +8,25 @@ process integrity_coverage {
     // This process can only use a single CPU
     cpus 1
 
-	input:
-	set fastq_id, file(fastq_pair) from {{ input_channel }}
-	val gsize from IN_genome_size
-	val cov from IN_min_coverage
-	// This channel is for the custom options of the integrity_coverage.py
-	// script. See the script's documentation for more information.
-	val opts from Channel.value('')
+    input:
+    set fastq_id, file(fastq_pair) from {{ input_channel }}
+    val gsize from IN_genome_size
+    val cov from IN_min_coverage
+    // This channel is for the custom options of the integrity_coverage.py
+    // script. See the script's documentation for more information.
+    val opts from Channel.value('')
 
-	output:
-	set fastq_id,
-	    file(fastq_pair),
-	    file('*_encoding'),
-	    file('*_phred'),
-	    file('*_coverage'),
-	    file('*_max_len') optional true into MAIN_integrity
-	file('*_report') optional true into LOG_report_coverage1
-	set fastq_id, val("integrity_coverage_{{ pid }}"), file(".status"), file(".warning"), file(".fail") into STATUS_{{ pid }}
-	file ".report.json"
+    output:
+    set fastq_id,
+        file(fastq_pair),
+        file('*_encoding'),
+        file('*_phred'),
+        file('*_coverage'),
+        file('*_max_len') optional true into MAIN_integrity
+    file('*_report') optional true into LOG_report_coverage1
+    {% with task_name="integrity_coverage" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
 	script:
 	template "integrity_coverage.py"

--- a/assemblerflow/generator/templates/mlst.nf
+++ b/assemblerflow/generator/templates/mlst.nf
@@ -15,8 +15,9 @@ process mlst {
     output:
     file '*.mlst.txt' into LOG_mlst_{{ pid }}
     set fastq_id, file(assembly), file(".status") into MAIN_mlst_out_{{ pid }}
-    set fastq_id, val("mlst"), file(".status"), file(".warning"), file(".fail") into STATUS_{{ pid }}
-    file ".report.json"
+    {% with task_name="mlst" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     when:
     params.mlstRun  == true && params.annotationRun

--- a/assemblerflow/generator/templates/patho_typing.nf
+++ b/assemblerflow/generator/templates/patho_typing.nf
@@ -13,7 +13,9 @@ process patho_typing {
 
     output:
     file "patho_typing.report.txt"
-    set file(".report.json"), file(".status")
+    {% with task_name="patho_typing" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     script:
     """

--- a/assemblerflow/generator/templates/pilon.nf
+++ b/assemblerflow/generator/templates/pilon.nf
@@ -13,8 +13,9 @@ process pilon {
 
     output:
     set fastq_id, '*_polished.assembly.fasta' into {{ output_channel }}, pilon_report_{{ pid }}
-    set fastq_id, val("pilon"), file(".status"), file(".warning"), file(".fail") into STATUS_{{ pid }}
-    file ".report.json"
+    {% with task_name="pilon" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     script:
     """
@@ -42,7 +43,9 @@ process pilon_report {
 
     output:
     file "*_assembly_report.csv" into pilon_report_out_{{ pid }}
-    file ".report.json"
+    {% with task_name="pilon_report" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     script:
     template "assembly_report.py"

--- a/assemblerflow/generator/templates/process_spades.nf
+++ b/assemblerflow/generator/templates/process_spades.nf
@@ -16,9 +16,10 @@ process process_spades {
 
     output:
     set fastq_id, file('*.assembly.fasta') optional true into {{ output_channel }}
-    set fastq_id, val("process_spades"), file(".status"), file(".warning"), file(".fail") into STATUS_{{ pid }}
     file '*.report.csv' optional true
-    file ".report.json"
+    {% with task_name="process_spades" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     when:
     params.stopAt != "process_spades"

--- a/assemblerflow/generator/templates/prokka.nf
+++ b/assemblerflow/generator/templates/prokka.nf
@@ -12,7 +12,9 @@ process prokka {
 
     output:
     file "${fastq_id}/*"
-    set fastq_id, val("prokka"), file(".status"), file(".warning"), file(".fail") into STATUS_{{ pid }}
+    {% with task_name="prokka" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     when:
     params.prokkaRun == true && params.annotationRun

--- a/assemblerflow/generator/templates/seq_typing.nf
+++ b/assemblerflow/generator/templates/seq_typing.nf
@@ -15,7 +15,9 @@ process seq_typing {
 
     output:
     file "seq_typing.report.txt"
-    set file(".report.json"), file(".status")
+    {% with task_name="seq_typing" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     script:
     """

--- a/assemblerflow/generator/templates/skesa.nf
+++ b/assemblerflow/generator/templates/skesa.nf
@@ -12,7 +12,9 @@ process skesa {
 
     output:
     set fastq_id, file('*_skesa.assembly.fasta') optional true into {{ output_channel }}
-    set fastq_id, val("skesa"), file(".status"), file(".warning"), file(".fail") into STATUS_{{ pid }}
+    {% with task_name="skesa" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     script:
     """

--- a/assemblerflow/generator/templates/spades.nf
+++ b/assemblerflow/generator/templates/spades.nf
@@ -14,8 +14,9 @@ process spades {
 
     output:
     set fastq_id, file('*_spades.assembly.fasta') optional true into {{ output_channel }}
-    set fastq_id, val("spades"), file(".status"), file(".warning"), file(".fail") into STATUS_{{ pid }}
-    file ".report.json"
+    {% with task_name="spades" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     when:
     params.stopAt != "spades"

--- a/assemblerflow/generator/templates/status_compiler.nf
+++ b/assemblerflow/generator/templates/status_compiler.nf
@@ -5,19 +5,23 @@ Reports the status of a sample in any given process.
 process status {
 
     tag { fastq_id }
+    publishDir "pipeline_status/$fastq_id"
 
     input:
-    set fastq_id, task_name, status, warning, fail from {{ status_channels }}
+    set fastq_id, task_name, status, warning, fail, file(log) from {{ status_channels }}
 
     output:
-    file 'status_*' into master_status
-    file 'warning_*' into master_warning
-    file 'fail_*' into master_fail
+    file '*.status' into master_status
+    file '*.warning' into master_warning
+    file '*.fail' into master_fail
+    file '*.log'
 
     """
-    echo $fastq_id, $task_name, \$(cat $status) > status_${fastq_id}_${task_name}
-    echo $fastq_id, $task_name, \$(cat $warning) > warning_${fastq_id}_${task_name}
-    echo $fastq_id, $task_name, \$(cat $fail) > fail_${fastq_id}_${task_name}
+    echo $fastq_id, $task_name, \$(cat $status) > ${task_name}_${fastq_id}.status
+    echo $fastq_id, $task_name, \$(cat $warning) > ${task_name}_${fastq_id}.warning
+    echo $fastq_id, $task_name, \$(cat $fail) > ${task_name}_${fastq_id}.fail
+    echo "\$(cat .command.log)" > ${task_name}_${fastq_id}.log
+    echo teste
     """
 }
 

--- a/assemblerflow/generator/templates/status_compiler.nf
+++ b/assemblerflow/generator/templates/status_compiler.nf
@@ -5,7 +5,7 @@ Reports the status of a sample in any given process.
 process status {
 
     tag { fastq_id }
-    publishDir "pipeline_status/$fastq_id"
+    publishDir "pipeline_status/$task_name"
 
     input:
     set fastq_id, task_name, status, warning, fail, file(log) from {{ status_channels }}

--- a/assemblerflow/generator/templates/trimmomatic.nf
+++ b/assemblerflow/generator/templates/trimmomatic.nf
@@ -13,9 +13,10 @@ process trimmomatic {
 
     output:
     set fastq_id, "${fastq_id}_*P*" optional true into {{ output_channel }}
-    set fastq_id, val("trimmomatic_{{ pid }}"), file(".status"), file(".warning"), file(".fail") into STATUS_{{ pid }}
     file 'trimmomatic_report.csv'
-    file ".report.json"
+    {% with task_name="trimmomatic" %}
+    {%- include "compiler_channels.txt" ignore missing -%}
+    {% endwith %}
 
     when:
     params.stopAt != "trimmomatic"


### PR DESCRIPTION
This PR implements an automatic status/log collection system for all pipeline processes. When adding the following placeholder in the output statement of the process:

```
    {% with task_name="process_name" %}
    {%- include "compiler_channels.txt" ignore missing -%}
    {% endwith %}
```

This will automatically link the process with a status compiler process that stores the `.status`, `.log`, `.fail` and `.warning` dotfiles in the `pipeline_status` directory at the project root. 