### PR TITLE
Runtime directives

### DIFF
--- a/assemblerflow/generator/engine.py
+++ b/assemblerflow/generator/engine.py
@@ -155,7 +155,10 @@ class NextflowGenerator:
 
         Returns
         -------
-
+        str
+            Process name
+        dict or None
+            Process directives
         """
 
         directives = None

--- a/assemblerflow/generator/pipeline_parser.py
+++ b/assemblerflow/generator/pipeline_parser.py
@@ -293,8 +293,6 @@ def parse_pipeline(pipeline_str):
         with open(pipeline_str) as fh:
             pipeline_str = "".join([x.strip() for x in fh.readlines()])
 
-    print(pipeline_str)
-
     # Perform pipeline insanity checks
     insanity_checks(pipeline_str)
 

--- a/assemblerflow/generator/process.py
+++ b/assemblerflow/generator/process.py
@@ -468,6 +468,35 @@ class Process:
         logger.debug("Setting forks attribute to: {}".format(self.forks))
         self._context = {**self._context, **{"forks": "\n".join(self.forks)}}
 
+    def update_directives(self, directives_dict):
+        """Updates the directives attribute from a dictionary object.
+
+        This will only update the directives for processes that have been
+        defined in the subclass.
+
+        Parameters
+        ----------
+        directives_dict : dict
+            Dictionary containing the directives that will be used to update
+            all nextflow processes.
+
+        """
+
+        valid_directives = ["cpus", "memory", "container", "version"]
+
+        for p, directives in self.directives.items():
+
+            for d, val in directives_dict.items():
+
+                # Prevent update when an invalid directive is provided
+                if d not in valid_directives:
+                    raise eh.ProcessError(
+                        "Invalid directive '{}'. The currently supported "
+                        "directives are: {}".format(
+                            d, " ".join(valid_directives)))
+
+                self.directives[p][d] = val
+
 
 class Status(Process):
     """Extends the Process methods to status-type processes

--- a/assemblerflow/generator/process.py
+++ b/assemblerflow/generator/process.py
@@ -1139,7 +1139,7 @@ class Abricate(Process):
 
         self.ignore_type = True
 
-        self.status_channels = ["STATUS_abricate", "STATUS_process_abricate"]
+        self.status_channels = ["STATUS_abricate"]
 
         self.link_start = None
         self.link_end.append({"link": "MAIN_assembly",

--- a/assemblerflow/generator/process.py
+++ b/assemblerflow/generator/process.py
@@ -376,7 +376,7 @@ class Process:
             context
         """
 
-        self.pid = kwargs.get("pid")
+        self.pid = "{}_{}".format(self.lane, kwargs.get("pid"))
 
         for i in self.status_channels:
             self.status_strs.append("{}_{}".format(i, self.pid))

--- a/assemblerflow/generator/process.py
+++ b/assemblerflow/generator/process.py
@@ -391,7 +391,8 @@ class Process:
         self._context = {**kwargs, **{"input_channel": self.input_channel,
                                       "output_channel": self.output_channel,
                                       "template": self.template,
-                                      "forks": "\n".join(self.forks)}}
+                                      "forks": "\n".join(self.forks),
+                                      "pid": self.pid}}
 
     def update_main_forks(self, sink):
         """Updates the forks attribute with the sink channel destination

--- a/assemblerflow/generator/templates/abricate.nf
+++ b/assemblerflow/generator/templates/abricate.nf
@@ -44,11 +44,6 @@ process process_abricate_{{ pid }} {
     input:
     file abricate_file from abricate_out_{{ pid }}.collect()
 
-    output:
-    {% with task_name="process_abricate" %}
-    {%- include "compiler_channels.txt" ignore missing -%}
-    {% endwith %}
-
     script:
     template "process_abricate.py"
 

--- a/assemblerflow/tests/test_assemblerflow.py
+++ b/assemblerflow/tests/test_assemblerflow.py
@@ -39,6 +39,15 @@ def test_check():
         af.run(args)
 
 
+def test_check_invalid():
+
+    args = af.get_args(["-t 'A B C()'", "-c", "-o teste.nf"])
+    sys.argv.append(1)
+
+    with pytest.raises(SystemExit):
+        af.run(args)
+
+
 def test_build_file(tmp):
 
     p = os.path.join(os.path.abspath(tmp), "teste.nf")

--- a/assemblerflow/tests/test_assemblerflow.py
+++ b/assemblerflow/tests/test_assemblerflow.py
@@ -47,8 +47,8 @@ def test_build_file(tmp):
     args = af.get_args(["-t integrity_coverage fastqc", "-o", "{}".format(p)])
     af.run(args)
 
-    assert os.listdir(tmp) == ["containers.config", "teste.nf",
-                               "resources.config"]
+    assert sorted(os.listdir(tmp)) == ["containers.config", "resources.config",
+                                       "teste.nf"]
 
 
 def test_build_file_2(tmp):

--- a/assemblerflow/tests/test_assemblerflow.py
+++ b/assemblerflow/tests/test_assemblerflow.py
@@ -47,10 +47,11 @@ def test_build_file(tmp):
     args = af.get_args(["-t integrity_coverage fastqc", "-o", "{}".format(p)])
     af.run(args)
 
-    assert os.listdir(tmp) == ["teste.nf"]
+    assert os.listdir(tmp) == ["containers.config", "teste.nf",
+                               "resources.config"]
 
 
-def test_build_file(tmp):
+def test_build_file_2(tmp):
 
     p = os.path.join(os.path.abspath(tmp), "teste.nf")
     sys.argv.append(1)

--- a/assemblerflow/tests/test_engine.py
+++ b/assemblerflow/tests/test_engine.py
@@ -318,7 +318,7 @@ def test_set_channels_secondary_chanels_link(multi_forks):
     assert [multi_forks.secondary_channels["SIDE_phred"][1]["end"],
             multi_forks.secondary_channels["SIDE_max_len"][1]["end"],
             multi_forks.secondary_channels["SIDE_max_len"][3]["end"]] == \
-           [[], ["SIDE_max_len_5"], ["SIDE_max_len_7"]]
+           [[], ["SIDE_max_len_4_5"], ["SIDE_max_len_6_7"]]
 
 
 def test_set_secondary_inputs_single(single_con):
@@ -376,13 +376,11 @@ def test_set_secondary_channels(multi_forks):
 
     print(multi_forks.main_raw_inputs)
 
-    print(p._context)
-
     assert [p._context["output_channel"], p._context["forks"]] == \
         ["_integrity_coverage_out_1_0",
          "\n_integrity_coverage_out_1_0.into{ integrity_coverage_out_1_0;"
-         "spades_in_1_4;skesa_in_1_5 }\n\n\nSIDE_max_len_1.set{"
-         " SIDE_max_len_5 }\n"]
+         "spades_in_1_4;skesa_in_1_5 }\n\n\nSIDE_max_len_1_1.set{"
+         " SIDE_max_len_4_5 }\n"]
 
 
 def test_set_secondary_channels_2(multi_forks):
@@ -414,7 +412,7 @@ def test_set_implicit_link(implicit_link_2):
 
     p = implicit_link_2.processes[1]
 
-    assert p.main_forks == ["integrity_coverage_out_1_0", "_LAST_fastq_3"]
+    assert p.main_forks == ["integrity_coverage_out_1_0", "_LAST_fastq_1_3"]
 
 
 def test_set_status_channels_multi(single_con):
@@ -426,8 +424,8 @@ def test_set_status_channels_multi(single_con):
          if isinstance(x, pc.StatusCompiler)][0]
 
     assert p._context["status_channels"] == \
-               "STATUS_integrity_coverage_1.mix(STATUS_fastqc2_2," \
-               "STATUS_fastqc2_report_2)"
+        "STATUS_integrity_coverage_1_1.mix(STATUS_fastqc2_1_2," \
+        "STATUS_fastqc2_report_1_2)"
 
 
 def test_set_status_channels_single(single_status):
@@ -438,18 +436,19 @@ def test_set_status_channels_single(single_status):
     p = [x for x in single_status.processes[::-1]
          if isinstance(x, pc.StatusCompiler)][0]
 
-    assert p._context["status_channels"] == "STATUS_spades_1"
+    assert p._context["status_channels"] == "STATUS_spades_1_1"
 
 
 def test_set_compiler_channels(single_status):
 
+    single_status.lane = 1
     single_status._set_channels()
     single_status._set_compiler_channels()
 
     p = [x for x in single_status.processes[::-1]
          if isinstance(x, pc.StatusCompiler)][0]
 
-    assert p._context["status_channels"] == "STATUS_spades_1"
+    assert p._context["status_channels"] == "STATUS_spades_1_1"
 
 
 def test_set_status_channels_no_status(single_status):

--- a/assemblerflow/tests/test_engine.py
+++ b/assemblerflow/tests/test_engine.py
@@ -534,3 +534,55 @@ def test_container_string_2(single_con):
 
     assert res == '\n$procA_2.container = "img:1"\n' \
                   '$procB_2.container = "img:latest"'
+
+
+def test_run_time_directives():
+
+    con = [{"input": {"process": "__init__", "lane": 1},
+            "output": {"process": "integrity_coverage", "lane": 1}},
+           {"input": {"process": "integrity_coverage", "lane": 1},
+            "output": {"process": "fastqc={'cpus':'3'}", "lane": 1}}]
+
+    nf = eg.NextflowGenerator(con, "teste.nf")
+
+    assert nf.processes[2].directives["fastqc2"]["cpus"] == "3"
+
+
+def test_run_time_directives_full():
+
+    con = [{"input": {"process": "__init__", "lane": 1},
+            "output": {"process": "integrity_coverage", "lane": 1}},
+           {"input": {"process": "integrity_coverage", "lane": 1},
+            "output": {"process": "fastqc={'cpus':'3','memory':'4GB',"
+                                  "'container':'img','version':'1'}",
+                       "lane": 1}}]
+
+    nf = eg.NextflowGenerator(con, "teste.nf")
+
+    assert [nf.processes[2].directives["fastqc2"]["cpus"],
+            nf.processes[2].directives["fastqc2"]["memory"],
+            nf.processes[2].directives["fastqc2"]["container"],
+            nf.processes[2].directives["fastqc2"]["version"]] == \
+           ["3", "4GB", "img", "1"]
+
+
+def test_run_time_directives_invalid():
+
+    con = [{"input": {"process": "__init__", "lane": 1},
+            "output": {"process": "integrity_coverage", "lane": 1}},
+           {"input": {"process": "integrity_coverage", "lane": 1},
+            "output": {"process": "fastqc={'cpus'", "lane": 1}}]
+
+    with pytest.raises(SystemExit):
+        eg.NextflowGenerator(con, "teste.nf")
+
+
+def test_run_time_directives_invalid2():
+
+    con = [{"input": {"process": "__init__", "lane": 1},
+            "output": {"process": "integrity_coverage", "lane": 1}},
+           {"input": {"process": "integrity_coverage", "lane": 1},
+            "output": {"process": "fastqc={'cpu':'2'}", "lane": 1}}]
+
+    with pytest.raises(eh.ProcessError):
+        eg.NextflowGenerator(con, "teste.nf")

--- a/assemblerflow/tests/test_processes.py
+++ b/assemblerflow/tests/test_processes.py
@@ -175,9 +175,10 @@ def test_channels_setup_status(process_wchannels):
 
     process_wchannels.status_channels = ["A", "B"]
 
+    process_wchannels.lane = 3
     process_wchannels.set_channels(pid=1)
 
-    assert process_wchannels.status_strs == ["A_1", "B_1"]
+    assert process_wchannels.status_strs == ["A_3_1", "B_3_1"]
 
 
 def test_update_main_fork_noprevious(process_wchannels):
@@ -196,26 +197,29 @@ def test_update_main_fork_noprevious(process_wchannels):
 
 def test_secondary_channels_multisink(process_wchannels):
 
+    process_wchannels.lane = 2
     process_wchannels.set_channels(pid=1)
     process_wchannels.set_secondary_channel("A", ["B", "C"])
 
-    assert process_wchannels.forks == ["\nA_1.into{ B;C }\n"]
+    assert process_wchannels.forks == ["\nA_2_1.into{ B;C }\n"]
 
 
 def test_secondary_channels_singlesink(process_wchannels):
 
+    process_wchannels.lane = 2
     process_wchannels.set_channels(pid=1)
     process_wchannels.set_secondary_channel("A", ["B"])
 
-    assert process_wchannels.forks == ["\nA_1.set{ B }\n"]
+    assert process_wchannels.forks == ["\nA_2_1.set{ B }\n"]
 
 
 def test_secondary_channels_duplicatesink(process_wchannels):
 
+    process_wchannels.lane = 1
     process_wchannels.set_channels(pid=1)
     process_wchannels.set_secondary_channel("A", ["B", "B"])
 
-    assert process_wchannels.forks == ["\nA_1.set{ B }\n"]
+    assert process_wchannels.forks == ["\nA_1_1.set{ B }\n"]
 
 
 def test_status_init(mock_status):

--- a/assemblerflow/tests/test_processes.py
+++ b/assemblerflow/tests/test_processes.py
@@ -307,3 +307,62 @@ def test_init_multi_secondary_inputs(mock_init):
 
     assert mock_init._context["secondary_inputs"] == \
         "IN_genome_size = Channel.value(params.genomeSize)\nOther"
+
+
+def test_directive_update():
+
+    p = pc.Spades(template="spades")
+
+    p.update_directives({"version": "3.9.0"})
+
+    assert p.directives["spades"]["version"] == "3.9.0"
+
+
+def test_directive_update2():
+
+    p = pc.FastQC(template="fastqc")
+
+    p.update_directives({"cpus": "3", "memory": "4GB"})
+
+    assert [p.directives["fastqc2"]["cpus"],
+            p.directives["fastqc2"]["memory"]] ==\
+           ["3", "4GB"]
+
+
+def test_directive_update3():
+
+    p = pc.Pilon(template="pilon")
+
+    p.update_directives({"cpus": "3", "memory": "4GB",
+                         "container": "another", "version": "1.0"})
+
+    assert [p.directives["pilon"]["cpus"],
+            p.directives["pilon"]["memory"],
+            p.directives["pilon"]["container"],
+            p.directives["pilon"]["version"]] == \
+           ["3", "4GB", "another", "1.0"]
+
+
+def test_directive_update4():
+
+    p = pc.Trimmomatic(template="trimmomatic")
+
+    p.update_directives({"cpus": "3", "memory": "{4.GB*task.attempt}",
+                         "container": "another", "version": "1.0"})
+
+    assert [p.directives["trimmomatic"]["cpus"],
+            p.directives["trimmomatic"]["memory"],
+            p.directives["trimmomatic"]["container"],
+            p.directives["trimmomatic"]["version"]] == \
+           ["3", "{4.GB*task.attempt}", "another", "1.0"]
+
+
+def test_directive_update_invalid():
+
+    p = pc.Trimmomatic(template="trimmomatic")
+
+    with pytest.raises(eh.ProcessError):
+        p.update_directives({"cpu": "3", "memory": "{4.GB*task.attempt}",
+                             "container": "another", "version": "1.0"})
+
+

--- a/assemblerflow/tests/test_processes.py
+++ b/assemblerflow/tests/test_processes.py
@@ -117,12 +117,13 @@ def test_main_raw_channel_invalid(mock_process):
 
 def test_channels_setup(process_wchannels):
 
+    process_wchannels.lane = 1
     process_wchannels.set_channels(pid=1)
 
     expected = {"input_channel": "in_channel",
                 "output_channel": "out_channel",
                 "template": process_wchannels.template,
-                "pid": 1,
+                "pid": "1_1",
                 "forks": ""}
 
     assert process_wchannels._context == expected
@@ -132,12 +133,13 @@ def test_channels_setup_withforks(process_wchannels):
 
     process_wchannels.forks = ["A", "B"]
 
+    process_wchannels.lane = 3
     process_wchannels.set_channels(pid=1)
 
     expected = {"input_channel": "in_channel",
                 "output_channel": "out_channel",
                 "template": process_wchannels.template,
-                "pid": 1,
+                "pid": "3_1",
                 "forks": "A\nB"}
 
     assert process_wchannels._context == expected
@@ -146,12 +148,13 @@ def test_channels_setup_withforks(process_wchannels):
 def test_setup_one_raw_fork(process_wchannels):
 
     process_wchannels.main_forks = ["A"]
+    process_wchannels.lane = 1
     process_wchannels.set_channels(pid=1)
 
     expected = {"input_channel": "in_channel",
                 "output_channel": "out_channel",
                 "template": process_wchannels.template,
-                "pid": 1,
+                "pid": "1_1",
                 "forks": "\nout_channel.set{ A }\n"}
 
     assert process_wchannels._context == expected
@@ -160,12 +163,13 @@ def test_setup_one_raw_fork(process_wchannels):
 def test_setup_multiple_raw_forks(process_wchannels):
 
     process_wchannels.main_forks = ["A", "B"]
+    process_wchannels.lane = 3
     process_wchannels.set_channels(pid=1)
 
     expected = {"input_channel": "in_channel",
                 "output_channel": "out_channel",
                 "template": process_wchannels.template,
-                "pid": 1,
+                "pid": "3_1",
                 "forks": "\nout_channel.into{ A;B }\n"}
 
     assert process_wchannels._context == expected


### PR DESCRIPTION
This PR introduces a the new feature of defining processes' directives at runtime. The currently supported directives are `cpus`, `memory`, `container` and `version`. The syntax in the pipeline string is:

```
-t "procA={'version':'1.0'} procB={'cpus':'2','memory':'4GB'}"
```

This syntax relies on a `=` symbol to separate the process name from the directives. The directives are then parsed as a regular JSON. Since this new syntax may bring some new problems when writing the pipeline string, a custom error message is provided when the directives cannot be parsed:

```
Could not parse directives for process 'spades'. The raw string is: spades={'version':'3.9.0'
Possible causes include:
        1. Spaces inside directives
        2. Missing '=' symbol before directives
        3. Missing quotes (' or ") around directives
A valid example: process_name={'cpus':'2'}
```

Further tests were also included for the new code. 