### PR TITLE
Extra inputs #42

### DIFF
--- a/assemblerflow/generator/engine.py
+++ b/assemblerflow/generator/engine.py
@@ -414,7 +414,8 @@ class NextflowGenerator:
         else:
             self.main_raw_inputs[process_input] = {
                 "channel": raw_in["channel"],
-                "channel_str": raw_in["channel_str"],
+                "channel_str": "{} = {}".format(raw_in["channel"],
+                                                raw_in["channel_str"]),
                 "raw_forks": [raw_in["input_channel"]]
             }
         logger.debug("[{}] Updated main raw inputs: {}".format(

--- a/assemblerflow/generator/engine.py
+++ b/assemblerflow/generator/engine.py
@@ -121,6 +121,10 @@ class NextflowGenerator:
 
         """
 
+        self.extra_inputs = {}
+        """
+        """
+
         self.status_channels = []
         """
         list: Stores the status channels from each process
@@ -414,8 +418,9 @@ class NextflowGenerator:
         else:
             self.main_raw_inputs[process_input] = {
                 "channel": raw_in["channel"],
-                "channel_str": "{} = {}".format(raw_in["channel"],
-                                                raw_in["channel_str"]),
+                "channel_str": "{} = {}".format(
+                    raw_in["channel"],
+                    raw_in["channel_str"].format(raw_in["params"])),
                 "raw_forks": [raw_in["input_channel"]]
             }
         logger.debug("[{}] Updated main raw inputs: {}".format(
@@ -424,7 +429,7 @@ class NextflowGenerator:
     def _update_secondary_inputs(self, p):
         """Given a process, this method updates the
         :attr:`~Process.secondary_inputs` attribute with the corresponding
-        secondary inputs of that channel.
+        secondary inputs of that process.
 
         Parameters
         ----------
@@ -440,6 +445,63 @@ class NextflowGenerator:
                     logger.debug("[{}] Added channel: {}".format(
                         p.template, ch["channel"]))
                     self.secondary_inputs[ch["params"]] = ch["channel"]
+
+    def _update_extra_inputs(self, p):
+        """Given a process, this method updates the
+        :attr:`~Process.extra_inputs` attribute with the corresponding extra
+        inputs of that process
+
+        Parameters
+        ----------
+        p : assemblerflow.Process.Process
+        """
+
+        if p.extra_input:
+            logger.debug("[{}] Found extra input: {}".format(
+                p.template, p.extra_input))
+
+            if p.extra_input == "default":
+                # Check if the default type is now present in the main raw
+                # inputs. If so, issue an error. The default param can only
+                # be used when not present in the main raw inputs
+                if p.input_type in self.main_raw_inputs:
+                    logger.error(colored_print(
+                        "\nThe default input param '{}' of the process '{}'"
+                        " is already specified as a main input parameter of"
+                        " the pipeline. Please choose a different extra_input"
+                        " name.".format(p.input_type, p.template), "red_bold"))
+                    sys.exit(1)
+                param = p.input_type
+            else:
+                param = p.extra_input
+
+            dest_channel = "EXTRA_{}_{}".format(p.template, p.pid)
+
+            if param not in self.extra_inputs:
+                self.extra_inputs[param] = {
+                    "input_type": p.input_type,
+                    "channels": [dest_channel]
+                }
+            else:
+                if self.extra_inputs[param]["input_type"] != p.input_type:
+                    logger.error(colored_print(
+                        "\nThe extra_input parameter '{}' for process"
+                        " '{}' was already defined with a different "
+                        "input type '{}'. Please choose a different "
+                        "extra_input name.".format(
+                            p.input_type, p.template,
+                            self.extra_inputs[param]["input_type"]),
+                        "red_bold"))
+                    sys.exit(1)
+                self.extra_inputs[param]["channels"].append(dest_channel)
+
+            logger.debug("[{}] Added extra channel '{}' linked to param: '{}' "
+                         "".format(p.template, param,
+                                   self.extra_inputs[param]))
+            p.update_main_input(
+                "{}.mix({})".format(p.input_channel, dest_channel)
+            )
+
 
     def _get_fork_tree(self, p):
         """
@@ -613,12 +675,14 @@ class NextflowGenerator:
 
             self._update_secondary_inputs(p)
 
+            self._update_extra_inputs(p)
+
             self._update_secondary_channels(p)
 
             logger.info(colored_print(
                 "\tChannels set for {} \u2713".format(p.template)))
 
-    def _set_secondary_inputs(self):
+    def _set_init_process(self):
         """Sets the main raw inputs and secondary inputs on the init process
 
         This method will fetch the :class:`assemblerflow.process.Init` process
@@ -641,6 +705,8 @@ class NextflowGenerator:
         logger.debug("Setting secondary inputs: "
                      "{}".format(self.secondary_inputs))
         init_process.set_secondary_inputs(self.secondary_inputs)
+        logger.debug("Setting extra inputs: {}".format(self.extra_inputs))
+        init_process.set_extra_inputs(self.extra_inputs)
 
     def _set_secondary_channels(self):
         """Sets the secondary channels for the pipeline
@@ -1003,7 +1069,7 @@ class NextflowGenerator:
 
         self._set_channels()
 
-        self._set_secondary_inputs()
+        self._set_init_process()
 
         logger.info(colored_print(
             "\tSuccessfully set {} secondary input(s) \u2713".format(

--- a/assemblerflow/generator/process.py
+++ b/assemblerflow/generator/process.py
@@ -46,13 +46,13 @@ class Process:
             "params": "fastq",
             "default_value": "'fastq/*_{1,2}.*'",
             "channel": "IN_fastq_raw",
-            "channel_str": "IN_fastq_raw = Channel.fromFilePairs(params.fastq)"
+            "channel_str": "Channel.fromFilePairs(params.fastq)"
         },
         "fasta": {
             "params": "fasta",
             "default_value": "'fasta/*.fasta'",
             "channel": "IN_fasta_raw",
-            "channel_str": "IN_fasta_raw = Channel.fromPath(params.fasta)"
+            "channel_str": "Channel.fromPath(params.fasta)"
                            ".map{ it -> [it.toString().tokenize('/').last()"
                            ".tokenize('.').first(), it] }"
         },
@@ -60,7 +60,7 @@ class Process:
             "params": "accessions",
             "default_value": "null",
             "channel": "IN_accessions_raw",
-            "channel_str": "IN_accessions_raw = Channel.fromPath("
+            "channel_str": "Channel.fromPath("
                            "params.accessions)"
         }
     }

--- a/assemblerflow/generator/process.py
+++ b/assemblerflow/generator/process.py
@@ -46,22 +46,21 @@ class Process:
             "params": "fastq",
             "default_value": "'fastq/*_{1,2}.*'",
             "channel": "IN_fastq_raw",
-            "channel_str": "Channel.fromFilePairs(params.fastq)"
+            "channel_str": "Channel.fromFilePairs(params.{})"
         },
         "fasta": {
             "params": "fasta",
             "default_value": "'fasta/*.fasta'",
             "channel": "IN_fasta_raw",
-            "channel_str": "Channel.fromPath(params.fasta)"
-                           ".map{ it -> [it.toString().tokenize('/').last()"
-                           ".tokenize('.').first(), it] }"
+            "channel_str": "Channel.fromPath(params.{})"
+                           ".map{{ it -> [it.toString().tokenize('/')"
+                           ".last().tokenize('.').first(), it] }}"
         },
         "accessions": {
             "params": "accessions",
             "default_value": "null",
             "channel": "IN_accessions_raw",
-            "channel_str": "Channel.fromPath("
-                           "params.accessions)"
+            "channel_str": "Channel.fromPath(params.{})"
         }
     }
     """
@@ -210,6 +209,16 @@ class Process:
             }
         """
         self.secondary_input_str = ""
+
+        self.extra_input = ""
+        """
+        str:  with the name of the params that will be used to provide 
+        extra input into the process. This extra input will be mixed with
+        the main input channel using nextflow's ``mix`` operator. Its
+        channel will be defined at the start of the pipeline, based on the
+        ``channel_str`` key of the :attr:`~Process.RAW_MAPPING` for the 
+        corresponding input type.
+        """
 
         self.params = {}
         """
@@ -409,6 +418,11 @@ class Process:
                                       "template": self.template,
                                       "forks": "\n".join(self.forks),
                                       "pid": self.pid}}
+
+    def update_main_input(self, input_str):
+
+        self.input_channel = input_str
+        self._context["input_channel"] = self.input_channel
 
     def update_main_forks(self, sink):
         """Updates the forks attribute with the sink channel destination
@@ -622,6 +636,44 @@ class Init(Process):
         secondary_input_str = "\n".join(list(channel_dict.values()))
         self._context = {**self._context,
                          **{"secondary_inputs": secondary_input_str}}
+
+    def set_extra_inputs(self, channel_dict):
+        """Sets the initial definition of the extra input channels.
+
+        The ``channel_dict`` argument should contain the input type and
+        destination channel of each parameter (which is the key)::
+
+            channel_dict = {
+                "param1": {
+                    "input_type": "fasta"
+                    "channels": ["abricate_2_3", "chewbbaca_3_4"]
+                }
+            }
+
+        Parameters
+        ----------
+        channel_dict : dict
+            Dictionary with the extra_input parameter as key, and a dictionary
+            as a value with the input_type and destination channels
+        """
+
+        extra_inputs = []
+
+        for param, info in channel_dict.items():
+
+            channel_name = "IN_{}_extraInput".format(param)
+            channel_str = self.RAW_MAPPING[info["input_type"]]["channel_str"]
+            extra_inputs.append("{} = {}".format(channel_name,
+                                                 channel_str.format(param)))
+
+            op = "set" if len(info["channels"]) == 1 else "into"
+            extra_inputs.append("{}.{}{{ {} }}".format(
+                channel_name, op, ";".join(info["channels"])))
+
+        self._context = {
+            **self._context,
+            **{"extra_inputs": "\n".join(extra_inputs)}
+        }
 
 
 class DownloadReads(Process):

--- a/assemblerflow/generator/process.py
+++ b/assemblerflow/generator/process.py
@@ -212,11 +212,11 @@ class Process:
 
         self.extra_input = ""
         """
-        str:  with the name of the params that will be used to provide 
+        str:  with the name of the params that will be used to provide
         extra input into the process. This extra input will be mixed with
         the main input channel using nextflow's ``mix`` operator. Its
         channel will be defined at the start of the pipeline, based on the
-        ``channel_str`` key of the :attr:`~Process.RAW_MAPPING` for the 
+        ``channel_str`` key of the :attr:`~Process.RAW_MAPPING` for the
         corresponding input type.
         """
 

--- a/assemblerflow/generator/templates/abricate.nf
+++ b/assemblerflow/generator/templates/abricate.nf
@@ -17,9 +17,6 @@ process abricate_{{ pid }} {
     {%- include "compiler_channels.txt" ignore missing -%}
     {% endwith %}
 
-    when:
-    params.abricateRun == true && params.annotationRun
-
     script:
     """
     {

--- a/assemblerflow/generator/templates/assembly_mapping.nf
+++ b/assemblerflow/generator/templates/assembly_mapping.nf
@@ -16,9 +16,6 @@ process assembly_mapping_{{ pid }} {
     {%- include "compiler_channels.txt" ignore missing -%}
     {% endwith %}
 
-    when:
-    params.stopAt != "assembly_mapping"
-
     script:
     """
     {

--- a/assemblerflow/generator/templates/chewbbaca.nf
+++ b/assemblerflow/generator/templates/chewbbaca.nf
@@ -35,9 +35,6 @@ process chewbbaca_{{ pid }} {
     {%- include "compiler_channels.txt" ignore missing -%}
     {% endwith %}
 
-    when:
-    params.chewbbacaRun == true
-
     script:
     """
     {

--- a/assemblerflow/generator/templates/fastqc.nf
+++ b/assemblerflow/generator/templates/fastqc.nf
@@ -18,9 +18,6 @@ process fastqc2_{{ pid }} {
     {%- include "compiler_channels.txt" ignore missing -%}
     {% endwith %}
 
-    when:
-    params.stopAt != "fastqc2"
-
     script:
     template "fastqc.py"
 }

--- a/assemblerflow/generator/templates/fastqc_trimmomatic.nf
+++ b/assemblerflow/generator/templates/fastqc_trimmomatic.nf
@@ -130,9 +130,6 @@ process trimmomatic_{{ pid }} {
     {%- include "compiler_channels.txt" ignore missing -%}
     {% endwith %}
 
-    when:
-    params.stopAt != "trimmomatic"
-
     script:
     template "trimmomatic.py"
 

--- a/assemblerflow/generator/templates/init.nf
+++ b/assemblerflow/generator/templates/init.nf
@@ -5,6 +5,9 @@
 // Placeholder for secondary input channels
 {{ secondary_inputs }}
 
+// Placeholder for extra input channels
+{{ extra_inputs }}
+
 // Placeholder to fork the raw input channel
 {{ forks }}
 

--- a/assemblerflow/generator/templates/mlst.nf
+++ b/assemblerflow/generator/templates/mlst.nf
@@ -18,9 +18,6 @@ process mlst_{{ pid }} {
     {%- include "compiler_channels.txt" ignore missing -%}
     {% endwith %}
 
-    when:
-    params.mlstRun  == true && params.annotationRun
-
     script:
     """
     {

--- a/assemblerflow/generator/templates/process_spades.nf
+++ b/assemblerflow/generator/templates/process_spades.nf
@@ -22,8 +22,6 @@ process process_spades_{{ pid }} {
     {%- include "compiler_channels.txt" ignore missing -%}
     {% endwith %}
 
-    when:
-    params.stopAt != "process_spades"
 
     script:
     template "process_assembly.py"

--- a/assemblerflow/generator/templates/prokka.nf
+++ b/assemblerflow/generator/templates/prokka.nf
@@ -16,9 +16,6 @@ process prokka_{{ pid }} {
     {%- include "compiler_channels.txt" ignore missing -%}
     {% endwith %}
 
-    when:
-    params.prokkaRun == true && params.annotationRun
-
     script:
     """
     {

--- a/assemblerflow/generator/templates/spades.nf
+++ b/assemblerflow/generator/templates/spades.nf
@@ -18,9 +18,6 @@ process spades_{{ pid }} {
     {%- include "compiler_channels.txt" ignore missing -%}
     {% endwith %}
 
-    when:
-    params.stopAt != "spades"
-
     script:
     template "spades.py"
 

--- a/assemblerflow/generator/templates/trimmomatic.nf
+++ b/assemblerflow/generator/templates/trimmomatic.nf
@@ -19,9 +19,6 @@ process trimmomatic_{{ pid }} {
     {%- include "compiler_channels.txt" ignore missing -%}
     {% endwith %}
 
-    when:
-    params.stopAt != "trimmomatic"
-
     script:
     template "trimmomatic.py"
 

--- a/assemblerflow/tests/test_engine.py
+++ b/assemblerflow/tests/test_engine.py
@@ -327,7 +327,7 @@ def test_set_channels_secondary_chanels_link(multi_forks):
 def test_set_secondary_inputs_single(single_con):
 
     single_con._set_channels()
-    single_con._set_secondary_inputs()
+    single_con._set_init_process()
 
     p = single_con.processes[0]
 
@@ -341,7 +341,7 @@ def test_set_secondary_inputs_single(single_con):
 def test_set_secondary_inputs_raw_forks(raw_forks):
 
     raw_forks._set_channels()
-    raw_forks._set_secondary_inputs()
+    raw_forks._set_init_process()
 
     p = raw_forks.processes[0]
 
@@ -357,7 +357,7 @@ def test_set_secondary_inputs_raw_forks(raw_forks):
 def test_set_secondary_inputs_multi_raw(single_con_multi_raw):
 
     single_con_multi_raw._set_channels()
-    single_con_multi_raw._set_secondary_inputs()
+    single_con_multi_raw._set_init_process()
 
     p = single_con_multi_raw.processes[0]
 

--- a/assemblerflow/tests/test_engine.py
+++ b/assemblerflow/tests/test_engine.py
@@ -537,6 +537,77 @@ def test_container_string_2(single_con):
                   '$procB_2.container = "img:latest"'
 
 
+def test_extra_inputs_1():
+
+    con = [{"input": {"process": "__init__", "lane": 1},
+            "output": {"process": "integrity_coverage", "lane": 1}},
+           {"input": {"process": "integrity_coverage", "lane": 1},
+            "output": {"process": "fastqc={'extra_input':'teste'}", "lane": 1}}]
+
+    nf = eg.NextflowGenerator(con, "teste.nf")
+
+    assert nf.processes[2].extra_input == "teste"
+
+
+def test_extra_inputs_2():
+
+    con = [{"input": {"process": "__init__", "lane": 1},
+            "output": {"process": "integrity_coverage", "lane": 1}},
+           {"input": {"process": "integrity_coverage", "lane": 1},
+            "output": {"process": "spades", "lane": 1}},
+           {"input": {"process": "spades", "lane": 1},
+            "output": {"process": "abricate={'extra_input':'teste'}", "lane": 1}}
+           ]
+
+    nf = eg.NextflowGenerator(con, "teste.nf")
+
+    assert nf.processes[3].extra_input == "teste"
+
+
+def test_extra_inputs_default():
+
+    con = [{"input": {"process": "__init__", "lane": 1},
+            "output": {"process": "integrity_coverage", "lane": 1}},
+           {"input": {"process": "integrity_coverage", "lane": 1},
+            "output": {"process": "spades", "lane": 1}},
+           {"input": {"process": "spades", "lane": 1},
+            "output": {"process": "abricate={'extra_input':'default'}", "lane": 1}}
+           ]
+
+    nf = eg.NextflowGenerator(con, "teste.nf")
+
+    assert nf.processes[3].extra_input == "default"
+
+
+def test_extra_inputs_invalid():
+
+    con = [{"input": {"process": "__init__", "lane": 1},
+            "output": {"process": "integrity_coverage", "lane": 1}},
+           {"input": {"process": "integrity_coverage", "lane": 1},
+            "output": {"process": "fastqc={'extra_input':'default'}", "lane": 1}}]
+
+    nf = eg.NextflowGenerator(con, "teste.nf")
+
+    with pytest.raises(SystemExit):
+        nf._set_channels()
+
+
+def test_extra_inputs_invalid_2():
+
+    con = [{"input": {"process": "__init__", "lane": 1},
+            "output": {"process": "integrity_coverage", "lane": 1}},
+           {"input": {"process": "integrity_coverage", "lane": 1},
+            "output": {"process": "spades={'extra_input':'teste'}", "lane": 1}},
+           {"input": {"process": "spades", "lane": 1},
+            "output": {"process": "abricate={'extra_input':'teste'}", "lane": 1}}
+           ]
+
+    nf = eg.NextflowGenerator(con, "teste.nf")
+
+    with pytest.raises(SystemExit):
+        nf._set_channels()
+
+
 def test_run_time_directives():
 
     con = [{"input": {"process": "__init__", "lane": 1},

--- a/assemblerflow/tests/test_engine.py
+++ b/assemblerflow/tests/test_engine.py
@@ -564,7 +564,7 @@ def test_extra_inputs_2():
     assert nf.processes[3].extra_input == "teste"
 
 
-def test_extra_inputs_1():
+def test_extra_inputs_3():
 
     con = [{"input": {"process": "__init__", "lane": 1},
             "output": {"process": "integrity_coverage", "lane": 1}},

--- a/assemblerflow/tests/test_engine.py
+++ b/assemblerflow/tests/test_engine.py
@@ -564,6 +564,22 @@ def test_extra_inputs_2():
     assert nf.processes[3].extra_input == "teste"
 
 
+def test_extra_inputs_1():
+
+    con = [{"input": {"process": "__init__", "lane": 1},
+            "output": {"process": "integrity_coverage", "lane": 1}},
+           {"input": {"process": "integrity_coverage", "lane": 1},
+            "output": {"process": "fastqc={'extra_input':'teste'}", "lane": 1}}]
+
+    nf = eg.NextflowGenerator(con, "teste.nf")
+    nf._set_channels()
+
+    assert [list(nf.extra_inputs.keys())[0],
+            nf.extra_inputs["teste"]["input_type"],
+            nf.extra_inputs["teste"]["channels"]] == \
+           ["teste", "fastq", ["EXTRA_fastqc_1_2"]]
+
+
 def test_extra_inputs_default():
 
     con = [{"input": {"process": "__init__", "lane": 1},
@@ -575,8 +591,12 @@ def test_extra_inputs_default():
            ]
 
     nf = eg.NextflowGenerator(con, "teste.nf")
+    nf._set_channels()
 
-    assert nf.processes[3].extra_input == "default"
+    assert [list(nf.extra_inputs.keys())[0],
+            nf.extra_inputs["fasta"]["input_type"],
+            nf.extra_inputs["fasta"]["channels"]] == \
+           ["fasta", "fasta", ["EXTRA_abricate_1_3"]]
 
 
 def test_extra_inputs_invalid():


### PR DESCRIPTION
## User feature

This PR introduces a new feature where users can specify extra inputs for any process in the pipeline using the `extra_inputs` directive. For instance, considering the linear pipeline:

```
skesa chewbbaca
```

If the user wants to provide an additional set of fasta files to the chewbbaca process directly, it is now possible to:

```
skesa chewbbaca={'extra_input':'chewieInput'}
```

This will expose a new parameter named `chewieInput`, which can be used to specify a set o fasta files:

```
nextflow run (...) --chewieInput fasta/*.fasta
```

This pipeline will process the fastq files through `skesa` and `chewbbaca` and, in parallel, will also process the provide fasta in chewbbaca. 

It is also possible to provide any number of `extra_inputs` with forks in the pipeline. For instance, running an assembly pipeline with two assemblers can be defined as:

```
integrity_coverage trimmomatic (spades | skesa)
```

It is now possible to provide additional fastq files directly to the assemblers (without any trimming):

```
integrity_coverage trimmomatic (spades={'extra_input':'extraFastq'} | skesa={'extra_input':'extraFastq'})
# Or just to one assembler
integrity_coverage trimmomatic (spades={'extra_input':'extraFastq'} | skesa)
# Or different sets of fastq files to each
integrity_coverage trimmomatic (spades={'extra_input':'fastq1'} | skesa={'extra_input':'fastq2'})
```

Overall, this feature presents a flexible way of injecting input data directly into any process in the pipeline. However, it assumes that the user will provide the data of the adequate type in the extra parameters.

## Under the hood

This system takes advantage of nextflow's [mix](https://www.nextflow.io/docs/latest/operator.html#mix) to inject additional data into a process. The main input channel of a process that receives the `'extra_input':'teste'` directive will become:

```
main_channel.mix(EXTRA_process_1_1)
```

Assemblerflow will then handle the creation of the `EXTRA_process_1_1` channel, taking into consideration the expected input type of the process. If the process receives fastq data, `EXTRA_process_1_1` will be defined and forked at the beginning of the pipeline file:

```
extra_channel = Channel.fromFilePairs(params.teste)
extra_channel.set{ EXTRA_process_1_1 }
```

This fork is used by default to simplify the task of serving the same parameter to several processes. If the pipeline is defined as:

```
(spades={'extra_input':'teste'} | skesa={'extra_input':'teste'})
```

Then, the channel definition will only add a new channel to the fork:

```
extra_channel = Channel.fromFilePairs(params.teste)
extra_channel.set{ EXTRA_spades_1_1;EXTRA_skesa_2_2 }
```
