### PR TITLE
Dependencies

### DIFF
--- a/assemblerflow/assemblerflow.py
+++ b/assemblerflow/assemblerflow.py
@@ -50,6 +50,10 @@ def get_args(args=None):
                         help="This will copy the necessary templates and lib"
                              " files to the directory where the nextflow"
                              " pipeline will be generated")
+    parser.add_argument("-nd", "--no-dependecy", dest="no_dep",
+                        action="store_false",
+                        help="Do not automatically add dependencies to the"
+                             "pipeline.")
     parser.add_argument("-c", "--check-pipeline", dest="check_only",
                         action="store_const", const=True,
                         help="Check only the validity of the pipeline"
@@ -66,17 +70,6 @@ def get_args(args=None):
                         const=True, help="Set log to debug mode")
 
     return parser.parse_args(args)
-
-
-def check_arguments(args):
-
-    # Check if no args are passed
-    if len(sys.argv) == 1:
-        logger.info(colored_print("Please provide one of the supported "
-                                  "arguments!", "red_bold"))
-        return False
-
-    return True
 
 
 def check_arguments(args):
@@ -201,7 +194,8 @@ def run(args):
 
     nfg = NextflowGenerator(process_connections=pipeline_list,
                             nextflow_file=args.output_nf,
-                            pipeline_name=args.pipeline_name)
+                            pipeline_name=args.pipeline_name,
+                            auto_dependency=args.no_dep)
 
     logger.info(colored_print("Building your awesome pipeline..."))
 

--- a/assemblerflow/generator/engine.py
+++ b/assemblerflow/generator/engine.py
@@ -62,7 +62,8 @@ the format::
 class NextflowGenerator:
 
     def __init__(self, process_connections, nextflow_file,
-                 pipeline_name="assemblerflow", ignore_dependencies=False):
+                 pipeline_name="assemblerflow", ignore_dependencies=False,
+                 auto_dependency=True):
 
         self.processes = []
 
@@ -92,7 +93,8 @@ class NextflowGenerator:
         # Builds the connections in the processes, which parses the
         # process_connections dictionary into the self.processes attribute
         # list.
-        self._build_connections(process_connections, ignore_dependencies)
+        self._build_connections(process_connections, ignore_dependencies,
+                                auto_dependency)
 
         self.nf_file = nextflow_file
         """
@@ -220,7 +222,8 @@ class NextflowGenerator:
 
         return process_name, directives
 
-    def _build_connections(self, process_list, ignore_dependencies):
+    def _build_connections(self, process_list, ignore_dependencies,
+                           auto_dependency):
         """Parses the process connections dictionaries into a process list
 
         This method is called upon instantiation of the NextflowGenerator
@@ -255,20 +258,9 @@ class NextflowGenerator:
             if out_lane > self.lanes:
                 self.lanes = out_lane
 
-            # Get process names
-            try:
-                _p_in_name = con["input"]["process"]
-                p_in_name, _ = self._parse_process_name(_p_in_name)
-                logger.debug("[{}] Input channel: {}".format(p, p_in_name))
-                _p_out_name = con["output"]["process"]
-                p_out_name, out_directives = self._parse_process_name(
-                    _p_out_name)
-                logger.debug("[{}] Output channel: {}".format(p, p_out_name))
-            # Exception is triggered when the process name/directives cannot
-            # be processes.
-            except eh.ProcessError as ex:
-                logger.error(colored_print(ex.value, "red_bold"))
-                sys.exit(1)
+            # Get process names and directives for the output process
+            p_in_name, p_out_name, out_directives = self._get_process_names(
+                con, p)
 
             # Check if process is available or correctly named
             if p_out_name not in process_map:
@@ -354,16 +346,102 @@ class NextflowGenerator:
                 parent_lanes = self._get_fork_tree(out_lane)
                 for dep in out_process.dependencies:
                     if not self._search_tree_backwards(dep, parent_lanes):
-                        logger.error(colored_print(
-                            "\nThe following dependency of the process '{}' "
-                            "is missing: {}".format(p_out_name, dep),
-                            "red_bold"))
-                        sys.exit(1)
+                        if auto_dependency:
+                            self._add_dependency(
+                                out_process, dep, in_lane, out_lane, p)
+                        else:
+                            logger.error(colored_print(
+                                "\nThe following dependency of the process"
+                                " '{}' is missing: {}".format(p_out_name, dep),
+                                "red_bold"))
+                            sys.exit(1)
 
             self.processes.append(out_process)
 
         logger.debug("Completed connections: {}".format(self.processes))
         logger.debug("Fork tree: {}".format(self._fork_tree))
+
+    def _get_process_names(self, con, pid):
+        """Returns the input/output process names and output process directives
+
+        Parameters
+        ----------
+        con : dict
+            Dictionary with the connection information between two processes.
+
+        Returns
+        -------
+        input_name : str
+            Name of the input process
+        output_name : str
+            Name of the output process
+        output_directives : dict
+            Parsed directives from the output process
+        """
+
+        try:
+            _p_in_name = con["input"]["process"]
+            p_in_name, _ = self._parse_process_name(_p_in_name)
+            logger.debug("[{}] Input channel: {}".format(pid, p_in_name))
+            _p_out_name = con["output"]["process"]
+            p_out_name, out_directives = self._parse_process_name(
+                _p_out_name)
+            logger.debug("[{}] Output channel: {}".format(pid, p_out_name))
+        # Exception is triggered when the process name/directives cannot
+        # be processes.
+        except eh.ProcessError as ex:
+            logger.error(colored_print(ex.value, "red_bold"))
+            sys.exit(1)
+
+        return p_in_name, p_out_name, out_directives
+
+    def _add_dependency(self, p, template, inlane, outlane, pid):
+        """Automatically Adds a dependency of a process.
+
+        This method adds a template to the process list attribute as a
+        dependency. It will adapt the input lane, output lane and process
+        id of the process that depends on it.
+
+        Parameters
+        ----------
+        p : Process
+            Process class that contains the dependency.
+        template : str
+            Template name of the dependency.
+        inlane : int
+            Input lane.
+        outlane : int
+            Output lane.
+        pid : int
+            Process ID.
+        """
+
+        dependency_proc = process_map[template](template=template)
+
+        if dependency_proc.input_type != p.input_type:
+            logger.error("Cannot automatically add dependency with different"
+                         " input type. Input type of process '{}' is '{}."
+                         " Input type of dependency '{}' is '{}'".format(
+                            p.template, p.input_type, template,
+                            dependency_proc.input_type))
+
+        input_suf = "{}_{}_dep".format(inlane, pid)
+        output_suf = "{}_{}_dep".format(outlane, pid)
+        dependency_proc.set_main_channel_names(input_suf, output_suf, outlane)
+
+        # To insert the dependency process before the current process, we'll
+        # need to move the input channel name of the later to the former, and
+        # set a new connection between the dependency and the process.
+        dependency_proc.input_channel = p.input_channel
+        p.input_channel = dependency_proc.output_channel
+
+        # If the current process was the first in the pipeline, change the
+        # lanes so that the dependency becomes the first process
+        if not p.parent_lane:
+            p.parent_lane = outlane
+            dependency_proc.parent_lane = None
+
+        self.processes.append(dependency_proc)
 
     def _search_tree_backwards(self, template, parent_lanes):
         """Searches the process tree backwards in search of a provided process
@@ -395,7 +473,6 @@ class NextflowGenerator:
                 return True
 
         return False
-
 
     @staticmethod
     def _test_connection(parent_process, child_process):

--- a/assemblerflow/generator/pipeline_parser.py
+++ b/assemblerflow/generator/pipeline_parser.py
@@ -17,6 +17,7 @@ LANE_TOKEN = "|"
 # Token that closes a fork
 CLOSE_TOKEN = ")"
 
+
 def remove_inner_forks(text):
     """Recursively removes nested brackets
 

--- a/assemblerflow/tests/test_engine.py
+++ b/assemblerflow/tests/test_engine.py
@@ -25,7 +25,7 @@ def single_con():
 def single_status():
 
     con = [{"input": {"process": "__init__", "lane": 1},
-            "output": {"process": "spades", "lane": 1}}]
+            "output": {"process": "skesa", "lane": 1}}]
 
     return eg.NextflowGenerator(con, "teste.nf")
 
@@ -118,8 +118,8 @@ def multi_forks():
            {"input": {"process": "__init__", "lane": 0},
             "output": {"process": "seq_typing", "lane": 2}},
            {"input": {"process": "__init__", "lane": 0},
-            "output": {"process": "trimmomatic", "lane": 3}},
-           {"input": {"process": "trimmomatic", "lane": 3},
+            "output": {"process": "integrity_coverage", "lane": 3}},
+           {"input": {"process": "integrity_coverage", "lane": 3},
             "output": {"process": "check_coverage", "lane": 3}},
            {"input": {"process": "integrity_coverage", "lane": 1},
             "output": {"process": "spades", "lane": 4}},
@@ -143,7 +143,8 @@ def test_simple_init():
     for p in process_map:
 
         con[0]["output"]["process"] = p
-        nf = eg.NextflowGenerator(con, "teste/teste.nf")
+        nf = eg.NextflowGenerator(con, "teste/teste.nf",
+                                  ignore_dependencies=True)
 
         assert [len(nf.processes), nf.processes[1].template] == \
             [2, p]
@@ -183,8 +184,8 @@ def test_connections_invalid():
 def test_connections_ignore_type():
 
     con = [{"input": {"process": "__init__", "lane": 1},
-            "output": {"process": "spades", "lane": 1}},
-           {"input": {"process": "spades", "lane": 1},
+            "output": {"process": "skesa", "lane": 1}},
+           {"input": {"process": "skesa", "lane": 1},
             "output": {"process": "patho_typing", "lane": 1}}
            ]
 
@@ -427,7 +428,7 @@ def test_set_status_channels_single(single_status):
     p = [x for x in single_status.processes[::-1]
          if isinstance(x, pc.StatusCompiler)][0]
 
-    assert p._context["compile_channels"] == "STATUS_spades_1_1"
+    assert p._context["compile_channels"] == "STATUS_skesa_1_1"
 
 
 def test_set_compiler_channels(single_status):
@@ -439,7 +440,7 @@ def test_set_compiler_channels(single_status):
     p = [x for x in single_status.processes[::-1]
          if isinstance(x, pc.StatusCompiler)][0]
 
-    assert p._context["compile_channels"] == "STATUS_spades_1_1"
+    assert p._context["compile_channels"] == "STATUS_skesa_1_1"
 
 
 def test_set_status_channels_no_status(single_status):

--- a/assemblerflow/tests/test_engine.py
+++ b/assemblerflow/tests/test_engine.py
@@ -667,3 +667,72 @@ def test_run_time_directives_invalid2():
 
     with pytest.raises(eh.ProcessError):
         eg.NextflowGenerator(con, "teste.nf")
+
+
+def test_automatic_dependency():
+
+    con = [{"input": {"process": "__init__", "lane": 1},
+            "output": {"process": "spades", "lane": 1}}]
+
+    nf = eg.NextflowGenerator(con, "teste.nf")
+
+    assert nf.processes[1].template == "integrity_coverage"
+
+
+def test_automatic_dependency_2():
+
+    con = [{"input": {"process": "__init__", "lane": 1},
+            "output": {"process": "spades", "lane": 1}}]
+
+    nf = eg.NextflowGenerator(con, "teste.nf")
+
+    assert nf.processes[1].output_channel == nf.processes[2].input_channel
+
+
+def test_automatic_dependency_3():
+
+    con = [{"input": {"process": "__init__", "lane": 1},
+            "output": {"process": "spades", "lane": 1}}]
+
+    nf = eg.NextflowGenerator(con, "teste.nf")
+
+    assert [nf.processes[1].parent_lane, nf.processes[2].parent_lane] == \
+           [None, 1]
+
+
+def test_automatic_dependency_wfork():
+
+    con = [{"input": {"process": "__init__", "lane": 0},
+            "output": {"process": "spades", "lane": 1}},
+           {"input": {"process": "__init__", "lane": 0},
+            "output": {"process": "integrity_coverage", "lane": 1}}]
+
+    nf = eg.NextflowGenerator(con, "teste.nf")
+
+    assert nf.processes[1].template == "integrity_coverage"
+
+
+def test_automatic_dependency_wfork_2():
+
+    con = [{"input": {"process": "__init__", "lane": 0},
+            "output": {"process": "spades", "lane": 1}},
+           {"input": {"process": "__init__", "lane": 0},
+            "output": {"process": "integrity_coverage", "lane": 2}}]
+
+    nf = eg.NextflowGenerator(con, "teste.nf")
+    nf._set_channels()
+
+    assert len(nf.main_raw_inputs["fastq"]["raw_forks"]) == 2
+
+
+def test_automatic_dependency_multi():
+
+    con = [{"input": {"process": "__init__", "lane": 1},
+            "output": {"process": "trimmomatic", "lane": 1}},
+           {"input": {"process": "trimmomatic", "lane": 1},
+            "output": {"process": "spades", "lane": 1}}]
+
+    nf = eg.NextflowGenerator(con, "teste.nf")
+
+    assert len([x for x in nf.processes
+                if x.template == "integrity_coverage"]) == 1

--- a/assemblerflow/tests/test_engine.py
+++ b/assemblerflow/tests/test_engine.py
@@ -669,6 +669,15 @@ def test_run_time_directives_invalid2():
         eg.NextflowGenerator(con, "teste.nf")
 
 
+def test_not_automatic_dependency():
+
+    con = [{"input": {"process": "__init__", "lane": 1},
+            "output": {"process": "spades", "lane": 1}}]
+
+    with pytest.raises(SystemExit):
+        eg.NextflowGenerator(con, "teste.nf", auto_dependency=False)
+
+
 def test_automatic_dependency():
 
     con = [{"input": {"process": "__init__", "lane": 1},


### PR DESCRIPTION
This PR introduces a new feature(#56) of automatically adding dependencies to processes in the pipeline, instead of simply raising and error. For instance, the pipeline:

```
spades
```

will automatically become `integrity_coverage spades`.

If multiple processes depend of the same process (both `spades` and `trimmomatic` depend on `integrity_coverage`), the dependency is added only once per lane, before the first process with the dependency. Therefore, the pipeline:

```
trimmomatic (spades | skesa)
```

becomes:

```
integrity_coverage trimmomatic (spades | skesa)
```